### PR TITLE
Feature/spot page layout wrapup

### DIFF
--- a/src/pages/Spot/PhotoPreview.jsx
+++ b/src/pages/Spot/PhotoPreview.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { useEffect, useCallback } from "react";
 
 export default function PhotoPreview({
   photos,
@@ -7,6 +8,34 @@ export default function PhotoPreview({
   onNext,
   onPrev,
 }) {
+  //防止不必要的重複渲染和eventlistener重複添加
+  const handlePreviewWithKeyboard = useCallback(
+    (event) => {
+      switch (event.key) {
+        case "Escape":
+          onClose();
+          break;
+        case "ArrowLeft":
+          onPrev();
+          break;
+        case "ArrowRight":
+          onNext();
+          break;
+        default:
+          return;
+      }
+    },
+    [onClose, onPrev, onNext],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handlePreviewWithKeyboard);
+
+    return () => {
+      window.removeEventListener("keydown", handlePreviewWithKeyboard);
+    };
+  }, [handlePreviewWithKeyboard]);
+
   return (
     <div className="fixed inset-0 z-30 flex items-center justify-center bg-black bg-opacity-75">
       <button

--- a/src/pages/Spot/PhotoPreview.jsx
+++ b/src/pages/Spot/PhotoPreview.jsx
@@ -28,13 +28,13 @@ export default function PhotoPreview({
       </button>
       <button
         onClick={onPrev}
-        className={`absolute left-4 ${currentIndex === 0 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}
+        className={`absolute left-4 rounded-full bg-slate-400 bg-opacity-30 p-[2px] ${currentIndex === 0 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="currentColor"
-          className="size-9"
+          className="size-6 md:size-8"
         >
           <path
             fillRule="evenodd"
@@ -46,13 +46,13 @@ export default function PhotoPreview({
       <img src={photos[currentIndex]} className="max-h-full max-w-full" />
       <button
         onClick={onNext}
-        className={`absolute right-4 ${currentIndex === photos.length - 1 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}
+        className={`absolute right-4 rounded-full bg-slate-400 bg-opacity-30 p-[2px] ${currentIndex === photos.length - 1 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="currentColor"
-          className="size-9"
+          className="size-6 md:size-8"
         >
           <path
             fillRule="evenodd"

--- a/src/pages/Spot/PhotoPreview.jsx
+++ b/src/pages/Spot/PhotoPreview.jsx
@@ -26,7 +26,10 @@ export default function PhotoPreview({
           />
         </svg>
       </button>
-      <button onClick={onPrev} className="absolute left-4 text-white">
+      <button
+        onClick={onPrev}
+        className={`absolute left-4 ${currentIndex === 0 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
@@ -41,7 +44,10 @@ export default function PhotoPreview({
         </svg>
       </button>
       <img src={photos[currentIndex]} className="max-h-full max-w-full" />
-      <button onClick={onNext} className="absolute right-4 text-white">
+      <button
+        onClick={onNext}
+        className={`absolute right-4 ${currentIndex === photos.length - 1 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"

--- a/src/pages/Spot/PhotoPreview.jsx
+++ b/src/pages/Spot/PhotoPreview.jsx
@@ -43,7 +43,10 @@ export default function PhotoPreview({
           />
         </svg>
       </button>
-      <img src={photos[currentIndex]} className="max-h-full max-w-full" />
+      <img
+        src={photos[currentIndex]}
+        className="max-h-full max-w-full select-none"
+      />
       <button
         onClick={onNext}
         className={`absolute right-4 rounded-full bg-slate-400 bg-opacity-30 p-[2px] ${currentIndex === photos.length - 1 ? "text-gray-800 hover:cursor-not-allowed" : "text-white"}`}

--- a/src/pages/Spot/index.jsx
+++ b/src/pages/Spot/index.jsx
@@ -120,24 +120,24 @@ export default function Spot() {
   }
   return (
     <div className="px-6 py-6 xl:mx-auto xl:w-[1200px]">
-      <div className="imageContainer relative flex w-full flex-row gap-2 rounded-lg md:h-[500px]">
+      <div className="group relative flex w-full flex-row gap-2 rounded-lg md:h-[500px]">
         <div className="w-full md:w-[70%]">
           <img
             src={photos[0]}
             onClick={() => handlePhotoClick(0)}
-            className="h-full w-full rounded-lg object-cover shadow-lg hover:cursor-pointer"
+            className="h-full w-full rounded-lg object-cover opacity-100 shadow-lg transition-all duration-500 ease-in-out hover:cursor-pointer group-hover:opacity-70 hover:group-hover:opacity-100"
           />
         </div>
         <div className="hidden w-[30%] flex-col gap-2 md:flex">
           <img
             src={photos[1]}
             onClick={() => handlePhotoClick(1)}
-            className="h-1/2 w-full rounded-lg object-cover shadow-lg hover:cursor-pointer"
+            className="h-1/2 w-full rounded-lg object-cover opacity-100 shadow-lg transition-all duration-500 ease-in-out hover:cursor-pointer group-hover:opacity-70 hover:group-hover:opacity-100"
           />
           <img
             src={photos[2]}
             onClick={() => handlePhotoClick(2)}
-            className="h-1/2 w-full rounded-lg object-cover shadow-lg hover:cursor-pointer"
+            className="h-1/2 w-full rounded-lg object-cover opacity-100 shadow-lg transition-all duration-500 ease-in-out hover:cursor-pointer group-hover:opacity-70 hover:group-hover:opacity-100"
           />
         </div>
         <div
@@ -174,7 +174,7 @@ export default function Spot() {
               viewBox="0 0 24 24"
               strokeWidth="1.1"
               stroke="currentColor"
-              className="inline-block h-auto w-[48px] align-middle text-gray-600 transition-colors duration-700 ease-in-out hover:cursor-pointer hover:fill-[#006c98] hover:text-[#006c98] md:h-9 md:w-9"
+              className="inline-block h-auto w-[48px] align-middle text-gray-600 hover:cursor-pointer hover:fill-[#006c98] hover:text-[#006c98] md:h-9 md:w-9"
             >
               <path
                 strokeLinecap="round"

--- a/src/pages/Spot/index.jsx
+++ b/src/pages/Spot/index.jsx
@@ -116,14 +116,14 @@ export default function Spot() {
   return (
     <div className="px-6 py-6 xl:mx-auto xl:w-[1200px]">
       <div className="imageContainer flex w-full flex-row gap-2 rounded-lg md:h-[500px]">
-        <div className="w-[70%]">
+        <div className="w-full md:w-[70%]">
           <img
             src={photos[0]}
             onClick={() => handlePhotoClick(0)}
             className="h-full w-full rounded-lg object-cover shadow-lg hover:cursor-pointer"
           />
         </div>
-        <div className="flex w-[30%] flex-col gap-2">
+        <div className="hidden w-[30%] flex-col gap-2 md:flex">
           <img
             src={photos[1]}
             onClick={() => handlePhotoClick(1)}

--- a/src/pages/Spot/index.jsx
+++ b/src/pages/Spot/index.jsx
@@ -120,7 +120,7 @@ export default function Spot() {
   }
   return (
     <div className="px-6 py-6 xl:mx-auto xl:w-[1200px]">
-      <div className="imageContainer flex w-full flex-row gap-2 rounded-lg md:h-[500px]">
+      <div className="imageContainer relative flex w-full flex-row gap-2 rounded-lg md:h-[500px]">
         <div className="w-full md:w-[70%]">
           <img
             src={photos[0]}
@@ -139,6 +139,27 @@ export default function Spot() {
             onClick={() => handlePhotoClick(2)}
             className="h-1/2 w-full rounded-lg object-cover shadow-lg hover:cursor-pointer"
           />
+        </div>
+        <div
+          id="photoNumberBox"
+          className="absolute bottom-2 right-2 flex select-none flex-row items-center justify-center gap-1 rounded-xl bg-gray-900 bg-opacity-60 px-2 text-sm text-white hover:cursor-pointer md:bottom-4 md:right-4 md:text-base"
+          onClick={() => handlePhotoClick(0)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="size-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+            />
+          </svg>
+          <p>{photos.length}</p>
         </div>
       </div>
       <div id="productInfo" className="flex flex-col py-6 lg:flex-row">

--- a/src/pages/Spot/index.jsx
+++ b/src/pages/Spot/index.jsx
@@ -246,7 +246,7 @@ export default function Spot() {
         </div>
         <div
           id="orderContainer"
-          className="mt-10 flex flex-col rounded border-[1px] border-gray-200 px-3 shadow-md lg:mt-0 lg:w-[30%] lg:self-start"
+          className="mt-10 flex flex-col rounded border-[1px] border-gray-200 px-3 shadow-md lg:sticky lg:top-[30%] lg:mt-0 lg:w-[30%] lg:self-start"
         >
           <div className="mb-3 mt-5">
             <span className="mr-2 text-2xl">

--- a/src/pages/Spot/index.jsx
+++ b/src/pages/Spot/index.jsx
@@ -43,6 +43,11 @@ export default function Spot() {
     }
   }, [spots, id, navigate]);
 
+  //Render後頁面到頂部
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   function formatCurrency(number) {
     return new Intl.NumberFormat("zh-TW", {
       style: "currency",


### PR DESCRIPTION
[Website URL](https://witz-ec201--ellie-suf90tsc.web.app/spot?id=a9a38231-13c7-4b04-8245-b9ff60b99637)

## Description
1. 新增圖片的細節處理
2. 調整進入頁面的scrollbar位置
3. 訂購按鈕調整成sticky，隨著頁面滾動上下移動

## Test Plan

- 整體
1. 進入頁面時，scrollbar應置頂。

- 圖片
1. 檢查RWD，小於576px時只顯示一張，大於576px時顯示三張。
2. 在右下角顯示圖片總數量，點擊總數量也會顯示圖片檢視畫面。
3. 當任一張照片被hover時，該張照片opacity 1，其他張照片opacity 0.7。

- 圖片檢視畫面
1. 新增上/下一張按鈕的背景
2. 在第一張和最後一張照片disable上/下一張按鈕。
3. 可用鍵盤控制圖片檢視畫面，鍵盤右鍵：下一張，鍵盤左鍵：上一張，Esc鍵：關閉檢視畫面。

- 訂購按鈕
1. 檢查按鈕是否隨著頁面滾動上下移動。