### PR TITLE
fix: modify layout details

### DIFF
--- a/src/pages/Spot/index.jsx
+++ b/src/pages/Spot/index.jsx
@@ -57,22 +57,6 @@ export default function Spot() {
     }).format(number);
   }
 
-  // 將 description 按 <br> 進行分割並渲染
-  const renderDescription = (description) => {
-    return description
-      .split(/(<br\s*\/?>)/i) // 使用正則表達式分割 <br> 標籤
-      .filter(Boolean) // 過濾掉空字符串
-      .map((part, index) =>
-        part.match(/(<br\s*\/?>)/i) ? (
-          <br key={index} />
-        ) : (
-          <span className="whitespace-pre-wrap" key={index}>
-            {part}
-          </span>
-        ),
-      );
-  };
-
   useEffect(() => {
     const updateClickCount = async () => {
       try {
@@ -114,7 +98,7 @@ export default function Spot() {
 
   if (!spot) {
     return (
-      <div className="flex h-screen items-center justify-center">加載中…</div>
+      <div className="flex h-screen items-center justify-center">Loading…</div>
     );
   }
   return (
@@ -275,8 +259,8 @@ export default function Spot() {
             <h2 className="mb-4 text-lg font-bold text-gray-900 md:text-xl">
               景點介紹
             </h2>
-            <div className="text-base text-gray-600">
-              {spot ? renderDescription(spot.description) : null}
+            <div className="whitespace-pre-wrap text-justify text-base text-gray-600">
+              {spot.description}
             </div>
           </div>
           <hr className="w-full" />
@@ -284,7 +268,9 @@ export default function Spot() {
             <h2 className="mb-4 text-lg font-bold text-gray-900 md:text-xl">
               交通方式
             </h2>
-            <p className="text-gray-600">{spot.transportation}</p>
+            <p className="whitespace-pre-wrap text-justify text-gray-600">
+              {spot.transportation}
+            </p>
           </div>
           {/*map*/}
           <hr className="w-full" />

--- a/src/pages/SpotManage/AddForm.jsx
+++ b/src/pages/SpotManage/AddForm.jsx
@@ -250,7 +250,7 @@ export default function AddForm() {
         </label>
         <textarea
           id="description"
-          className="h-56 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50"
+          className="h-72 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50"
           {...register("description", { required: true })}
         />
         {errors.description && (

--- a/src/pages/SpotManage/Details.jsx
+++ b/src/pages/SpotManage/Details.jsx
@@ -66,12 +66,12 @@ export default function Details({ spot }) {
         <div className="col-span-1 mb-2 ml-4 font-semibold text-gray-700">
           詳細介紹
         </div>
-        <div className="col-span-6 mb-4 mr-4 text-gray-600">
+        <div className="col-span-6 mb-4 mr-4 whitespace-pre-wrap text-justify text-gray-600">
           {spot.description}
         </div>
 
         {/* 交通資訊 */}
-        <div className="col-span-1 mb-2 ml-4 font-semibold text-gray-700">
+        <div className="col-span-1 mb-2 ml-4 whitespace-pre-wrap text-justify font-semibold text-gray-700">
           交通資訊
         </div>
         <div className="col-span-6 mb-4 text-gray-600">

--- a/src/pages/SpotManage/EditForm.jsx
+++ b/src/pages/SpotManage/EditForm.jsx
@@ -11,7 +11,6 @@ export default function EditForm({ showEditForm }) {
     handleSubmit,
     control,
     formState: { errors, isSubmitting, isValid },
-    reset,
   } = useForm({
     mode: "onBlur", // 驗證模式 (onChange, onBlur, onSubmit, all)
     defaultValues: {
@@ -257,7 +256,7 @@ export default function EditForm({ showEditForm }) {
         </label>
         <textarea
           id="description"
-          className="h-56 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50"
+          className="h-72 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50"
           {...register("description", { required: true })}
         />
         {errors.description && (

--- a/src/pages/SpotManage/index.jsx
+++ b/src/pages/SpotManage/index.jsx
@@ -20,7 +20,15 @@ export default function SpotManage() {
   );
 
   if (role === 1) {
-    return <div className="">你沒有權限~無法編輯此頁面</div>;
+    return (
+      <div className="w-4/5 bg-white px-7 py-5">
+        <div className="flex h-full w-full items-center justify-center bg-gray-200 text-center">
+          管理者沒有權限
+          <br />
+          無法編輯此頁面
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
[Website URL](https://witz-ec201--ellie-suf90tsc.web.app/backstage/spot-manage)

## Description
景點頁、景點管理頁Layout調整

## Test Plan
1. 用小編權限的管理帳號進入景點管理頁，檢查是否顯示「無權限」提示。
2. 進入任一景點頁，檢查介紹的文字顯示是否為左右對齊 (text-justify)。